### PR TITLE
Adjust AsyncMDNSResolver construction to have a default mDNS timeout

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,7 +13,7 @@ The only public *aiohttp_asyncmdnsresolver.api* class is :class:`AsyncMDNSResolv
    >>> from aiohttp_asyncmdnsresolver.api import AsyncMDNSResolver
 
 
-.. class:: AsyncMDNSResolver(*args*, *, async_zeroconf, timeout, **kwargs)
+.. class:: AsyncMDNSResolver(*args, *, async_zeroconf=None, mdns_timeout=5.0, **kwargs)
 
    This class functions the same as ``aiohttp.resolver.AsyncResolver``,
    but with the added ability to resolve mDNS queries.
@@ -22,8 +22,9 @@ The only public *aiohttp_asyncmdnsresolver.api* class is :class:`AsyncMDNSResolv
         passed, it will be used to resolve mDNS queries. If not, a new
         instance will be created.
 
-    :param float timeout: The timeout for the mDNS query in seconds. If not provided
-        the default timeout is 5 seconds.
+    :param float mdns_timeout: The timeout for the mDNS query in seconds. If not provided
+        the default timeout is 5 seconds. If the mdns_timeout is set to 0, the
+        query will only use the cache and will not perform a new query.
 
    Example::
 

--- a/src/aiohttp_asyncmdnsresolver/_impl.py
+++ b/src/aiohttp_asyncmdnsresolver/_impl.py
@@ -77,12 +77,12 @@ class AsyncMDNSResolver(AsyncResolver):
         self,
         *args: Any,
         async_zeroconf: AsyncZeroconf | None = None,
-        timeout: float | None = None,
+        mdns_timeout: float | None = DEFAULT_TIMEOUT,
         **kwargs: Any,
     ) -> None:
         """Initialize the resolver."""
         super().__init__(*args, **kwargs)
-        self._timeout = timeout or DEFAULT_TIMEOUT
+        self._mdns_timeout = mdns_timeout
         self._aiozc_owner = async_zeroconf is None
         self._aiozc = async_zeroconf or AsyncZeroconf()
 
@@ -106,8 +106,10 @@ class AsyncMDNSResolver(AsyncResolver):
         if (
             info.load_from_cache(self._aiozc.zeroconf)
             or (
-                self._timeout
-                and await info.async_request(self._aiozc.zeroconf, self._timeout * 1000)
+                self._mdns_timeout
+                and await info.async_request(
+                    self._aiozc.zeroconf, self._mdns_timeout * 1000
+                )
             )
         ) and (addresses := info.ip_addresses_by_version(ip_version)):
             return [_to_resolve_result(host, port, address) for address in addresses]

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -17,7 +17,7 @@ from aiohttp_asyncmdnsresolver._impl import (
 @pytest_asyncio.fixture
 async def resolver() -> AsyncGenerator[AsyncMDNSResolver]:
     """Return a resolver."""
-    resolver = AsyncMDNSResolver(timeout=0.1)
+    resolver = AsyncMDNSResolver(mdns_timeout=0.1)
     yield resolver
     await resolver.close()
 
@@ -26,7 +26,7 @@ async def resolver() -> AsyncGenerator[AsyncMDNSResolver]:
 async def custom_resolver() -> AsyncGenerator[AsyncMDNSResolver]:
     """Return a resolver."""
     aiozc = AsyncZeroconf()
-    resolver = AsyncMDNSResolver(timeout=0.1, async_zeroconf=aiozc)
+    resolver = AsyncMDNSResolver(mdns_timeout=0.1, async_zeroconf=aiozc)
     yield resolver
     await resolver.close()
     await aiozc.async_close()
@@ -198,7 +198,7 @@ async def test_resolve_mdns_passed_in_asynczeroconf(
 async def test_create_destroy_resolver() -> None:
     """Test the resolver can be created and destroyed."""
     aiozc = AsyncZeroconf()
-    resolver = AsyncMDNSResolver(timeout=0.1, async_zeroconf=aiozc)
+    resolver = AsyncMDNSResolver(mdns_timeout=0.1, async_zeroconf=aiozc)
     await resolver.close()
     await aiozc.async_close()
     assert resolver._aiozc is None
@@ -208,7 +208,7 @@ async def test_create_destroy_resolver() -> None:
 @pytest.mark.asyncio
 async def test_create_destroy_resolver_no_aiozc() -> None:
     """Test the resolver can be created and destroyed."""
-    resolver = AsyncMDNSResolver(timeout=0.1)
+    resolver = AsyncMDNSResolver(mdns_timeout=0.1)
     await resolver.close()
     assert resolver._aiozc is None
     assert resolver._aiozc_owner is True


### PR DESCRIPTION
Forward looking change to rename `timeout` to `mdns_timeout` since its could conflict in the future.
