### PR TITLE
Migrate to using zeroconf built-in address resolver classes

### DIFF
--- a/CHANGES/19.misc.rst
+++ b/CHANGES/19.misc.rst
@@ -1,0 +1,1 @@
+Migrated to using zeroconf's built-in resolver classes -- by :user:`bdraco`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiohttp-asyncmdnsresolver"
-dependencies = ["aiodns>=3.2.0", "aiohttp>=3.10.0", "zeroconf>=0.132.0"]
+dependencies = ["aiodns>=3.2.0", "aiohttp>=3.10.0", "zeroconf>=0.142.0"]
 description = "An async resolver for aiohttp that supports MDNS"
 dynamic = ["version"]
 license = {file = "LICENSE"}

--- a/src/aiohttp_asyncmdnsresolver/_impl.py
+++ b/src/aiohttp_asyncmdnsresolver/_impl.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import socket
 from typing import Any
-from zeroconf.asyncio import (
-    AsyncZeroconf,
-)
+from zeroconf.asyncio import AsyncZeroconf
 from zeroconf import (
     AddressResolver,
     AddressResolverIPv4,

--- a/src/aiohttp_asyncmdnsresolver/_impl.py
+++ b/src/aiohttp_asyncmdnsresolver/_impl.py
@@ -4,45 +4,27 @@ from __future__ import annotations
 
 import socket
 from typing import Any
-from zeroconf import IPVersion
-from zeroconf.asyncio import AsyncZeroconf, AsyncServiceInfo
+from zeroconf.asyncio import (
+    AsyncZeroconf,
+)
+from zeroconf import (
+    AddressResolver,
+    AddressResolverIPv4,
+    AddressResolverIPv6,
+    IPVersion,
+)
 from aiohttp.resolver import AsyncResolver, ResolveResult
 from ipaddress import IPv4Address, IPv6Address
 
-
-class IPv6orIPv4HostResolver(AsyncServiceInfo):
-    """Resolve a host name to an IP address."""
-
-    @property
-    def _is_complete(self) -> bool:
-        """The ServiceInfo has all expected properties."""
-        return bool(self._ipv4_addresses) or bool(self._ipv6_addresses)
-
-
-class IPv6HostResolver(AsyncServiceInfo):
-    """Resolve a host name to an IP address."""
-
-    @property
-    def _is_complete(self) -> bool:
-        """The ServiceInfo has all expected properties."""
-        return bool(self._ipv6_addresses)
-
-
-class IPv4HostResolver(AsyncServiceInfo):
-    """Resolve a host name to an IP address."""
-
-    @property
-    def _is_complete(self) -> bool:
-        """The ServiceInfo has all expected properties."""
-        return bool(self._ipv4_addresses)
-
-
 DEFAULT_TIMEOUT = 5.0
 
-_FAMILY_TO_RESOLVER_CLASS = {
-    socket.AF_INET: IPv4HostResolver,
-    socket.AF_INET6: IPv6HostResolver,
-    socket.AF_UNSPEC: IPv6orIPv4HostResolver,
+_FAMILY_TO_RESOLVER_CLASS: dict[
+    socket.AddressFamily,
+    type[AddressResolver] | type[AddressResolverIPv4] | type[AddressResolverIPv6],
+] = {
+    socket.AF_INET: AddressResolverIPv4,
+    socket.AF_INET6: AddressResolverIPv6,
+    socket.AF_UNSPEC: AddressResolver,
 }
 _FAMILY_TO_IP_VERSION = {
     socket.AF_INET: IPVersion.V4Only,
@@ -98,11 +80,11 @@ class AsyncMDNSResolver(AsyncResolver):
         self, host: str, port: int, family: socket.AddressFamily
     ) -> list[ResolveResult]:
         """Resolve a host name to an IP address using mDNS."""
-        resolver_class: type[AsyncServiceInfo] = _FAMILY_TO_RESOLVER_CLASS[family]
+        resolver_class = _FAMILY_TO_RESOLVER_CLASS[family]
         ip_version: IPVersion = _FAMILY_TO_IP_VERSION[family]
         if host[-1] != ".":
             host += "."
-        info = resolver_class(".local.", host, server=host)
+        info = resolver_class(host)
         if (
             info.load_from_cache(self._aiozc.zeroconf)
             or (

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -7,11 +7,39 @@ from collections.abc import AsyncGenerator
 from unittest.mock import patch
 from ipaddress import IPv6Address, IPv4Address
 import socket
+from collections.abc import Generator
 from aiohttp_asyncmdnsresolver._impl import (
-    IPv4HostResolver,
-    IPv6HostResolver,
-    IPv6orIPv4HostResolver,
+    _FAMILY_TO_RESOLVER_CLASS,
+    AddressResolver,
+    AddressResolverIPv4,
+    AddressResolverIPv6,
 )
+
+
+class IPv6orIPv4HostResolver(AddressResolver):
+    """Patchable class for testing."""
+
+
+class IPv4HostResolver(AddressResolverIPv4):
+    """Patchable class for testing."""
+
+
+class IPv6HostResolver(AddressResolverIPv6):
+    """Patchable class for testing."""
+
+
+@pytest.fixture(autouse=True)
+def make_resolvers_patchable() -> Generator[None, None, None]:
+    """Patch the resolvers."""
+    with patch.dict(
+        _FAMILY_TO_RESOLVER_CLASS,
+        {
+            socket.AF_INET: IPv4HostResolver,
+            socket.AF_INET6: IPv6HostResolver,
+            socket.AF_UNSPEC: IPv6orIPv4HostResolver,
+        },
+    ):
+        yield
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Migrate to using zeroconf built-in address resolver classes. Reduce maintenance burden a bit in this library.

## Are there changes in behavior for the user?

Reduced mDNS traffic. Internal change only.
