### PR TITLE
Fix imports not being sorted

### DIFF
--- a/CHANGES/21.bugfix.rst
+++ b/CHANGES/21.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed unsorted import order -- by :user:`bdraco`.
+Fixed imports not being properly sorted -- by :user:`bdraco`.

--- a/CHANGES/21.bugfix.rst
+++ b/CHANGES/21.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed unsorted import order -- by :user:`bdraco`.

--- a/examples/run.py
+++ b/examples/run.py
@@ -1,5 +1,7 @@
 import asyncio
+
 import aiohttp
+
 from aiohttp_asyncmdnsresolver.api import AsyncMDNSResolver
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,8 @@ packages = ["aiohttp_asyncmdnsresolver"]
 
 [tool.setuptools.dynamic]
 version = {attr = "aiohttp_asyncmdnsresolver.__version__"}
+
+[tool.ruff]
+select = [
+    "I",  # isort formatting.
+]

--- a/src/aiohttp_asyncmdnsresolver/_impl.py
+++ b/src/aiohttp_asyncmdnsresolver/_impl.py
@@ -3,16 +3,17 @@
 from __future__ import annotations
 
 import socket
+from ipaddress import IPv4Address, IPv6Address
 from typing import Any
-from zeroconf.asyncio import AsyncZeroconf
+
+from aiohttp.resolver import AsyncResolver, ResolveResult
 from zeroconf import (
     AddressResolver,
     AddressResolverIPv4,
     AddressResolverIPv6,
     IPVersion,
 )
-from aiohttp.resolver import AsyncResolver, ResolveResult
-from ipaddress import IPv4Address, IPv6Address
+from zeroconf.asyncio import AsyncZeroconf
 
 DEFAULT_TIMEOUT = 5.0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Test conftest.py."""
 
-import sys
 import asyncio
+import sys
 
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 """Test we do not break the public API."""
 
-from aiohttp_asyncmdnsresolver import api, _impl
+from aiohttp_asyncmdnsresolver import _impl, api
 
 
 def test_api() -> None:

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -1,19 +1,20 @@
-from aiohttp_asyncmdnsresolver.api import AsyncMDNSResolver
-from aiohttp.resolver import ResolveResult
+import socket
+from collections.abc import AsyncGenerator, Generator
+from ipaddress import IPv4Address, IPv6Address
+from unittest.mock import patch
+
 import pytest
 import pytest_asyncio
+from aiohttp.resolver import ResolveResult
 from zeroconf.asyncio import AsyncZeroconf
-from collections.abc import AsyncGenerator
-from unittest.mock import patch
-from ipaddress import IPv6Address, IPv4Address
-import socket
-from collections.abc import Generator
+
 from aiohttp_asyncmdnsresolver._impl import (
     _FAMILY_TO_RESOLVER_CLASS,
     AddressResolver,
     AddressResolverIPv4,
     AddressResolverIPv6,
 )
+from aiohttp_asyncmdnsresolver.api import AsyncMDNSResolver
 
 
 class IPv6orIPv4HostResolver(AddressResolver):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The `I` rules where not enabled

## Are there changes in behavior for the user?

Because importing is not thread safe in CPython https://github.com/python/cpython/issues/83065 this could have lead to failure to import since `zeroconf.asyncio` was being imported ahead of `zeroconf`
