### PR TITLE
Add AsyncDualMDNSResolver class to resolve via DNS and mDNS

### DIFF
--- a/CHANGES/23.feature.rst
+++ b/CHANGES/23.feature.rst
@@ -1,0 +1,1 @@
+Created the :class:`aiohttp_asyncmdnsresolver.api.AsyncDualMDNSResolver` class to resolve ``.local`` names using both mDNS and DNS -- by :user:`bdraco`.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,5 +41,5 @@ and :class:`AsyncDualMDNSResolver`:
 .. class:: AsyncDualMDNSResolver(*args, *, async_zeroconf=None, mdns_timeout=5.0, **kwargs)
 
    This class functions the same as ``aiohttp.resolver.AsyncMDNSResolver`` and
-   takes the same arguments, but with the added ability to resolve mDNS queries
-   using both the mDNS and DNS protocols.
+   takes the same arguments, but with the added ability to resolve .local names
+   using both the mDNS and DNS protocols at the same time.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,7 +6,8 @@ Reference
 
 .. module:: aiohttp_asyncmdnsresolver.api
 
-The only public *aiohttp_asyncmdnsresolver.api* class is :class:`AsyncMDNSResolver`:
+The only public *aiohttp_asyncmdnsresolver.api* classes are :class:`AsyncMDNSResolver`
+and :class:`AsyncDualMDNSResolver`:
 
 .. doctest::
 
@@ -35,3 +36,10 @@ The only public *aiohttp_asyncmdnsresolver.api* class is :class:`AsyncMDNSResolv
        async with aiohttp.ClientSession(connector=connector) as session:
            async with session.get("http://KNKSADE41945.local.") as response:
                print(response.status)
+
+
+.. class: AsyncDualMDNSResolver(*args, *, async_zeroconf=None, mdns_timeout=5.0, **kwargs)
+
+   This class functions the same as ``aiohttp.resolver.AsyncMDNSResolver`` and
+   takes the same arguments, but with the added ability to resolve mDNS queries
+   using both the mDNS and DNS protocols.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,7 +38,7 @@ and :class:`AsyncDualMDNSResolver`:
                print(response.status)
 
 
-.. class: AsyncDualMDNSResolver(*args, *, async_zeroconf=None, mdns_timeout=5.0, **kwargs)
+.. class:: AsyncDualMDNSResolver(*args, *, async_zeroconf=None, mdns_timeout=5.0, **kwargs)
 
    This class functions the same as ``aiohttp.resolver.AsyncMDNSResolver`` and
    takes the same arguments, but with the added ability to resolve mDNS queries

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -40,6 +40,11 @@ and :class:`AsyncDualMDNSResolver`:
 
 .. class:: AsyncDualMDNSResolver(*args, *, async_zeroconf=None, mdns_timeout=5.0, **kwargs)
 
-   This class functions the same as ``aiohttp.resolver.AsyncMDNSResolver`` and
-   takes the same arguments, but with the added ability to resolve .local names
-   using both the mDNS and DNS protocols at the same time.
+   This resolver is a variant of :class:`AsyncMDNSResolver` that resolves ``.local``
+    names with both mDNS and regular DNS. It takes the same arguments as
+    :class:`AsyncMDNSResolver`, and is used in the same way.
+
+   - The first successful result from either resolver is returned.
+   - If both resolvers fail, an exception is raised.
+   - If both resolvers return results at the same time, the results are
+     combined and duplicates are removed.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,8 @@ Introduction
 Usage
 -----
 
-The API provides the :class:`AsyncMDNSResolver` and :class:`AsyncDualMDNSResolver` classes that can be
+The API provides the :class:`aiohttp_asyncmdnsresolver.api.AsyncMDNSResolver` and
+:class:`aiohttp_asyncmdnsresolver.api.AsyncDualMDNSResolver` classes that can be
 used to resolve mDNS queries and fallback to ``AsyncResolver`` for non-MDNS hosts.
 
 API documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,9 +15,8 @@ Introduction
 Usage
 -----
 
-The API provides a single ``AsyncMDNSResolver`` class that can be
-used to resolve mDNS queries and fallback to ``AsyncResolver`` for
-non-MDNS hosts.
+The API provides the :class:`AsyncMDNSResolver` and :class:`AsyncDualMDNSResolver` classes that can be
+used to resolve mDNS queries and fallback to ``AsyncResolver`` for non-MDNS hosts.
 
 API documentation
 -----------------

--- a/src/aiohttp_asyncmdnsresolver/_impl.py
+++ b/src/aiohttp_asyncmdnsresolver/_impl.py
@@ -138,9 +138,9 @@ class AsyncDualMDNSResolver(_AsyncMDNSResolverBase):
             mdns_task = loop.create_task(resolve_via_mdns)
             dns_task = loop.create_task(resolve_via_dns)
         await asyncio.wait((mdns_task, dns_task), return_when=asyncio.FIRST_COMPLETED)
-        if mdns_task.exception():
+        if mdns_task.done() and mdns_task.exception():
             await asyncio.wait((dns_task,), return_when=asyncio.ALL_COMPLETED)
-        elif dns_task.exception():
+        elif dns_task.done() and dns_task.exception():
             await asyncio.wait((mdns_task,), return_when=asyncio.ALL_COMPLETED)
         resolve_results: list[ResolveResult] = []
         exceptions: list[BaseException] = []

--- a/src/aiohttp_asyncmdnsresolver/_impl.py
+++ b/src/aiohttp_asyncmdnsresolver/_impl.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import socket
+import sys
+from contextlib import suppress
 from ipaddress import IPv4Address, IPv6Address
 from typing import Any
 
@@ -51,7 +54,7 @@ def _to_resolve_result(
     )
 
 
-class AsyncMDNSResolver(AsyncResolver):
+class _AsyncMDNSResolverBase(AsyncResolver):
     """Use the `aiodns`/`zeroconf` packages to make asynchronous DNS lookups."""
 
     def __init__(
@@ -66,14 +69,6 @@ class AsyncMDNSResolver(AsyncResolver):
         self._mdns_timeout = mdns_timeout
         self._aiozc_owner = async_zeroconf is None
         self._aiozc = async_zeroconf or AsyncZeroconf()
-
-    async def resolve(
-        self, host: str, port: int = 0, family: socket.AddressFamily = socket.AF_INET
-    ) -> list[ResolveResult]:
-        """Resolve a host name to an IP address."""
-        if host.endswith(".local") or host.endswith(".local."):
-            return await self._resolve_mdns(host, port, family)
-        return await super().resolve(host, port, family)
 
     async def _resolve_mdns(
         self, host: str, port: int, family: socket.AddressFamily
@@ -102,3 +97,77 @@ class AsyncMDNSResolver(AsyncResolver):
             await self._aiozc.async_close()
         await super().close()
         self._aiozc = None  # type: ignore[assignment] # break ref cycles early
+
+
+class AsyncMDNSResolver(_AsyncMDNSResolverBase):
+    """Use the `aiodns`/`zeroconf` packages to make asynchronous DNS lookups."""
+
+    async def resolve(
+        self, host: str, port: int = 0, family: socket.AddressFamily = socket.AF_INET
+    ) -> list[ResolveResult]:
+        """Resolve a host name to an IP address."""
+        if not host.endswith(".local") and not host.endswith(".local."):
+            return await super().resolve(host, port, family)
+        return await self._resolve_mdns(host, port, family)
+
+
+class AsyncDualMDNSResolver(_AsyncMDNSResolverBase):
+    """Use the `aiodns`/`zeroconf` packages to make asynchronous DNS lookups.
+
+    This resolver is a variant of `AsyncMDNSResolver` that resolves .local
+    names with both mDNS and regular DNS and combines the results.
+    """
+
+    async def resolve(
+        self, host: str, port: int = 0, family: socket.AddressFamily = socket.AF_INET
+    ) -> list[ResolveResult]:
+        """Resolve a host name to an IP address."""
+        if not host.endswith(".local") and not host.endswith(".local."):
+            return await super().resolve(host, port, family)
+        resolve_via_mdns = self._resolve_mdns(host, port, family)
+        resolve_via_dns = super().resolve(host, port, family)
+        loop = asyncio.get_running_loop()
+        if sys.version_info >= (3, 12):
+            mdns_task = asyncio.Task(resolve_via_mdns, loop=loop, eager_start=True)
+            dns_task = asyncio.Task(resolve_via_dns, loop=loop, eager_start=True)
+        else:
+            mdns_task = loop.create_task(resolve_via_mdns)
+            dns_task = loop.create_task(resolve_via_dns)
+        await asyncio.wait((mdns_task, dns_task), return_when=asyncio.FIRST_COMPLETED)
+        resolve_results: list[ResolveResult] = []
+        exceptions: list[BaseException] = []
+        seen_results: set[tuple[str, int, str]] = set()
+        for task in (mdns_task, dns_task):
+            if task.done():
+                if exc := task.exception():
+                    exceptions.append(exc)
+                else:
+                    for result in task.result():
+                        result_key = (
+                            result["hostname"],
+                            result["port"],
+                            result["host"],
+                        )
+                        if result_key not in seen_results:
+                            seen_results.add(result_key)
+                            resolve_results.append(result)
+            else:
+                task.cancel()
+                try:
+                    task.exception()  # clear log traceback
+                except asyncio.CancelledError:
+                    if (
+                        sys.version_info >= (3, 11)
+                        and (current_task := asyncio.current_task())
+                        and current_task.cancelling()
+                    ):
+                        raise
+
+        if resolve_results:
+            return resolve_results
+
+        exception_strings = ", ".join(
+            exc.strerror or str(exc) if isinstance(exc, OSError) else str(exc)
+            for exc in exceptions
+        )
+        raise OSError(None, exception_strings)

--- a/src/aiohttp_asyncmdnsresolver/_impl.py
+++ b/src/aiohttp_asyncmdnsresolver/_impl.py
@@ -138,6 +138,10 @@ class AsyncDualMDNSResolver(_AsyncMDNSResolverBase):
             mdns_task = loop.create_task(resolve_via_mdns)
             dns_task = loop.create_task(resolve_via_dns)
         await asyncio.wait((mdns_task, dns_task), return_when=asyncio.FIRST_COMPLETED)
+        if mdns_task.exception():
+            await asyncio.wait((dns_task,), return_when=asyncio.ALL_COMPLETED)
+        elif dns_task.exception():
+            await asyncio.wait((mdns_task,), return_when=asyncio.ALL_COMPLETED)
         resolve_results: list[ResolveResult] = []
         exceptions: list[BaseException] = []
         seen_results: set[tuple[str, int, str]] = set()

--- a/src/aiohttp_asyncmdnsresolver/_impl.py
+++ b/src/aiohttp_asyncmdnsresolver/_impl.py
@@ -150,6 +150,9 @@ class AsyncDualMDNSResolver(_AsyncMDNSResolverBase):
                 if exc := task.exception():
                     exceptions.append(exc)
                 else:
+                    # If we have multiple results, we need to remove duplicates
+                    # and combine the results. We put the mDNS results first
+                    # to prioritize them.
                     for result in task.result():
                         result_key = (
                             result["hostname"],

--- a/src/aiohttp_asyncmdnsresolver/_impl.py
+++ b/src/aiohttp_asyncmdnsresolver/_impl.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import socket
 import sys
-from contextlib import suppress
 from ipaddress import IPv4Address, IPv6Address
 from typing import Any
 

--- a/src/aiohttp_asyncmdnsresolver/_impl.py
+++ b/src/aiohttp_asyncmdnsresolver/_impl.py
@@ -157,7 +157,7 @@ class AsyncDualMDNSResolver(_AsyncMDNSResolverBase):
             else:
                 task.cancel()
                 try:
-                    task.exception()  # clear log traceback
+                    await task  # clear log traceback
                 except asyncio.CancelledError:
                     if (
                         sys.version_info >= (3, 11)

--- a/src/aiohttp_asyncmdnsresolver/_impl.py
+++ b/src/aiohttp_asyncmdnsresolver/_impl.py
@@ -114,9 +114,11 @@ class AsyncDualMDNSResolver(_AsyncMDNSResolverBase):
     """Use the `aiodns`/`zeroconf` packages to make asynchronous DNS lookups.
 
     This resolver is a variant of `AsyncMDNSResolver` that resolves .local
-    names with both mDNS and regular DNS. The first result from either
-    resolver is returned. If both resolvers fail, an exception is raised.
-    If both resolvers return results at the same time, the results are
+    names with both mDNS and regular DNS.
+
+    - The first successful result from either resolver is returned.
+    - If both resolvers fail, an exception is raised.
+    - If both resolvers return results at the same time, the results are
     combined and duplicates are removed.
     """
 

--- a/src/aiohttp_asyncmdnsresolver/_impl.py
+++ b/src/aiohttp_asyncmdnsresolver/_impl.py
@@ -115,7 +115,10 @@ class AsyncDualMDNSResolver(_AsyncMDNSResolverBase):
     """Use the `aiodns`/`zeroconf` packages to make asynchronous DNS lookups.
 
     This resolver is a variant of `AsyncMDNSResolver` that resolves .local
-    names with both mDNS and regular DNS and combines the results.
+    names with both mDNS and regular DNS. The first result from either
+    resolver is returned. If both resolvers fail, an exception is raised.
+    If both resolvers return results at the same time, the results are
+    combined and duplicates are removed.
     """
 
     async def resolve(

--- a/src/aiohttp_asyncmdnsresolver/api.py
+++ b/src/aiohttp_asyncmdnsresolver/api.py
@@ -1,5 +1,5 @@
 """Public API of the property caching library."""
 
-from ._impl import AsyncMDNSResolver
+from ._impl import AsyncDualMDNSResolver, AsyncMDNSResolver
 
-__all__ = ("AsyncMDNSResolver",)
+__all__ = ("AsyncMDNSResolver", "AsyncDualMDNSResolver")


### PR DESCRIPTION
## What do these changes do?

Adds a new resolver class that will resolve via mDNS and DNS and combine the results

## Are there changes in behavior for the user?

no

## Related issue number
https://github.com/home-assistant/core/issues/137479