### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,7 +46,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        pyver: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        pyver: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu, macos, windows]
         include:
           - pyver: pypy-3.10

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 color_output = true
 error_summary = true
 files =

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
   rev: 'v3.17.0'
   hooks:
   - id: pyupgrade
-    args: ['--py39-plus']
+    args: ['--py310-plus']
 
 - repo: https://github.com/codespell-project/codespell.git
   rev: v2.3.0
@@ -106,8 +106,8 @@ repos:
     - --html-report=.tox/.tmp/.mypy/python-3.13
     pass_filenames: false
   - id: mypy
-    alias: mypy-py39
-    name: MyPy, for Python 3.9
+    alias: mypy-py310
+    name: MyPy, for Python 3.10
     additional_dependencies:
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - pytest
@@ -115,10 +115,10 @@ repos:
     - aiohttp
     - zeroconf
     args:
-    - --python-version=3.9
-    - --txt-report=.tox/.tmp/.mypy/python-3.9
-    - --cobertura-xml-report=.tox/.tmp/.mypy/python-3.9
-    - --html-report=.tox/.tmp/.mypy/python-3.9
+    - --python-version=3.10
+    - --txt-report=.tox/.tmp/.mypy/python-3.10
+    - --cobertura-xml-report=.tox/.tmp/.mypy/python-3.10
+    - --html-report=.tox/.tmp/.mypy/python-3.10
     pass_filenames: false
 
 - repo: https://github.com/rhysd/actionlint.git

--- a/CHANGES/62.breaking.rst
+++ b/CHANGES/62.breaking.rst
@@ -1,0 +1,1 @@
+Dropped Python 3.9 support; the minimum supported Python version is now 3.10.

--- a/CHANGES/62.breaking.rst
+++ b/CHANGES/62.breaking.rst
@@ -1,1 +1,1 @@
-Dropped Python 3.9 support; the minimum supported Python version is now 3.10.
+Dropped Python 3.9 support; the minimum supported Python version is now 3.10 -- by :user:`bdraco`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "An async resolver for aiohttp that supports MDNS"
 dynamic = ["version"]
 license = "Apache-2.0"
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Drops Python 3.9; minimum supported Python is now 3.10. Updates requires-python, the CI matrix, the mypy target and pyupgrade target to match.