### PR TITLE
ci: migrate runners from setup-python to setup-uv

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,21 +35,21 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
     - name: Setup Python
-      uses: actions/setup-python@v6
+      # important: do not use system python
+      env:
+        UV_PYTHON_PREFERENCE: only-managed
+      uses: astral-sh/setup-uv@v8.1.0
       with:
-        python-version: 3.12
-        cache: 'pip'
-        cache-dependency-path: 'requirements/*.txt'
+        python-version: '3.12'
+        activate-environment: true
+        enable-cache: true
     - name: Install dependencies
-      uses: py-actions/py-dependency-install@v4
-      with:
-        path: requirements/dev.txt
+      run: uv pip install -r requirements/dev.txt
     - name: Install itself
-      run: |
-        pip install .
+      run: uv pip install .
     - name: Prepare twine checker
       run: |
-        pip install -U build twine wheel
+        uv pip install -U build twine wheel
         python -m build
     - name: Run twine checker
       run: |
@@ -70,18 +70,18 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
     - name: Setup Python ${{ matrix.pyver }}
-      uses: actions/setup-python@v6
+      # important: do not use system python
+      env:
+        UV_PYTHON_PREFERENCE: only-managed
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.pyver }}
-        cache: 'pip'
-        cache-dependency-path: 'requirements/*.txt'
+        activate-environment: true
+        enable-cache: true
     - name: Install dependencies
-      uses: py-actions/py-dependency-install@v4
-      with:
-        path: requirements/dev.txt
+      run: uv pip install -r requirements/dev.txt
     - name: Install itself
-      run: |
-        pip install .
+      run: uv pip install .
     - name: Run unittests
       run: python -m pytest
       env:
@@ -121,12 +121,16 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
     - name: Setup Python
-      uses: actions/setup-python@v6
+      # important: do not use system python
+      env:
+        UV_PYTHON_PREFERENCE: only-managed
+      uses: astral-sh/setup-uv@v8.1.0
       with:
-        python-version: 3.12
+        python-version: '3.12'
+        activate-environment: true
+        enable-cache: true
     - name: Install dependencies
-      run:
-        python -m pip install -U pip wheel setuptools build twine
+      run: uv pip install -U pip wheel setuptools build twine
     - name: Build dists
       run: |
         python -m build

--- a/CHANGES/76.contrib.rst
+++ b/CHANGES/76.contrib.rst
@@ -1,0 +1,3 @@
+Migrated CI runners from ``actions/setup-python`` to ``astral-sh/setup-uv``
+so dependencies and Python interpreters are provisioned via ``uv`` instead
+of system ``pip`` -- by :user:`aiolibsbot`.


### PR DESCRIPTION
Mirrors the uv-based setup used in yarl; uses astral-sh/setup-uv with managed Python and uv pip for installs, drops py-actions/py-dependency-install.

Applies to the lint, test, and deploy jobs in ci-cd.yml.