### PR TITLE
Cancel orphaned mDNS/DNS tasks when dual resolve is cancelled

### DIFF
--- a/CHANGES/69.bugfix.rst
+++ b/CHANGES/69.bugfix.rst
@@ -1,0 +1,1 @@
+Cancelled the in-flight mDNS and DNS lookup tasks when ``AsyncDualMDNSResolver.resolve()`` is itself cancelled, so a cancelled lookup no longer orphans tasks that keep running against the shared ``zeroconf`` instance -- by :user:`bdraco`.

--- a/src/aiohttp_asyncmdnsresolver/_impl.py
+++ b/src/aiohttp_asyncmdnsresolver/_impl.py
@@ -158,48 +158,64 @@ class AsyncDualMDNSResolver(_AsyncMDNSResolverBase):
         else:
             mdns_task = loop.create_task(resolve_via_mdns)
             dns_task = loop.create_task(resolve_via_dns)
-        await asyncio.wait((mdns_task, dns_task), return_when=asyncio.FIRST_COMPLETED)
-        if mdns_task.done() and mdns_task.exception():
-            await asyncio.wait((dns_task,), return_when=asyncio.ALL_COMPLETED)
-        elif dns_task.done() and dns_task.exception():
-            await asyncio.wait((mdns_task,), return_when=asyncio.ALL_COMPLETED)
-        resolve_results: list[ResolveResult] = []
-        exceptions: list[BaseException] = []
-        seen_results: set[tuple[str, int, str]] = set()
-        for task in (mdns_task, dns_task):
-            if task.done():
+        tasks = (mdns_task, dns_task)
+        try:
+            await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            if mdns_task.done() and mdns_task.exception():
+                await asyncio.wait((dns_task,), return_when=asyncio.ALL_COMPLETED)
+            elif dns_task.done() and dns_task.exception():
+                await asyncio.wait((mdns_task,), return_when=asyncio.ALL_COMPLETED)
+            resolve_results: list[ResolveResult] = []
+            exceptions: list[BaseException] = []
+            seen_results: set[tuple[str, int, str]] = set()
+            for task in tasks:
+                if not task.done():
+                    continue
                 if exc := task.exception():
                     exceptions.append(exc)
-                else:
-                    # If we have multiple results, we need to remove duplicates
-                    # and combine the results. We put the mDNS results first
-                    # to prioritize them.
-                    for result in task.result():
-                        result_key = (
-                            result["hostname"],
-                            result["port"],
-                            result["host"],
-                        )
-                        if result_key not in seen_results:
-                            seen_results.add(result_key)
-                            resolve_results.append(result)
-            else:
-                task.cancel()
-                try:
-                    await task  # clear log traceback
-                except asyncio.CancelledError:
-                    if (
-                        sys.version_info >= (3, 11)
-                        and (current_task := asyncio.current_task())
-                        and current_task.cancelling()
-                    ):
-                        raise
+                    continue
+                # If we have multiple results, we need to remove duplicates
+                # and combine the results. We put the mDNS results first
+                # to prioritize them.
+                for result in task.result():
+                    result_key = (
+                        result["hostname"],
+                        result["port"],
+                        result["host"],
+                    )
+                    if result_key not in seen_results:
+                        seen_results.add(result_key)
+                        resolve_results.append(result)
 
-        if resolve_results:
-            return resolve_results
+            if resolve_results:
+                return resolve_results
 
-        exception_strings = ", ".join(
-            exc.strerror or str(exc) if isinstance(exc, OSError) else str(exc)
-            for exc in exceptions
-        )
-        raise OSError(None, exception_strings)
+            exception_strings = ", ".join(
+                exc.strerror or str(exc) if isinstance(exc, OSError) else str(exc)
+                for exc in exceptions
+            )
+            raise OSError(None, exception_strings)
+        finally:
+            # asyncio.wait() does not cancel its child tasks when the awaiting
+            # coroutine is itself cancelled, so any still-pending task must be
+            # cancelled here to avoid orphaning work against the shared
+            # zeroconf instance. Also retrieve exceptions from already-done
+            # tasks so a fast-failing child cannot trigger a "Task exception
+            # was never retrieved" warning when the outer coroutine is
+            # cancelled before the result-collection loop runs.
+            pending = [task for task in tasks if not task.done()]
+            for task in tasks:
+                if task.done() and not task.cancelled():
+                    task.exception()
+            if pending:
+                for task in pending:
+                    task.cancel()
+                # return_exceptions=True ensures a child error cannot escape
+                # the finally and override the outcome of resolve().
+                await asyncio.gather(*pending, return_exceptions=True)
+                if (
+                    sys.version_info >= (3, 11)
+                    and (current_task := asyncio.current_task())
+                    and current_task.cancelling()
+                ):
+                    raise asyncio.CancelledError

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -653,3 +653,179 @@ async def test_no_cancel_swallow_dual_mdns_resolver(
         resolve_tasks.cancel()
         with pytest.raises(asyncio.CancelledError):
             await resolve_tasks
+
+
+@pytest.mark.asyncio
+async def test_cancel_cancels_child_tasks_dual_mdns_resolver(
+    dual_resolver: AsyncDualMDNSResolver,
+) -> None:
+    """Test cancelling resolve() cancels both child tasks instead of orphaning them."""
+    cancelled = {"mdns": False, "dns": False}
+
+    async def _mdns_op(*args: Any, **kwargs: Any) -> NoReturn:
+        try:
+            await asyncio.sleep(0.5)
+        except asyncio.CancelledError:
+            cancelled["mdns"] = True
+            raise
+        raise RuntimeError("Should not finish")
+
+    async def _dns_op(*args: Any, **kwargs: Any) -> NoReturn:
+        try:
+            await asyncio.sleep(0.5)
+        except asyncio.CancelledError:
+            cancelled["dns"] = True
+            raise
+        raise RuntimeError("Should not finish")
+
+    with (
+        patch("aiohttp_asyncmdnsresolver._impl.AsyncResolver.resolve", _dns_op),
+        patch.object(IPv4HostResolver, "async_request", _mdns_op),
+    ):
+        resolve_task = asyncio.create_task(dual_resolver.resolve("localhost.local."))
+        await asyncio.sleep(0.1)
+        resolve_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await resolve_task
+
+    assert cancelled["mdns"] is True
+    assert cancelled["dns"] is True
+
+
+@pytest.mark.asyncio
+async def test_loser_non_cancel_exception_does_not_override_result_dual_mdns_resolver(
+    dual_resolver: AsyncDualMDNSResolver,
+) -> None:
+    """Test loser raising a non-cancel exception during cleanup does not override winner."""
+
+    async def _dns_swallows_cancel_and_raises(*args: Any, **kwargs: Any) -> NoReturn:
+        try:
+            await asyncio.sleep(1.0)
+        except asyncio.CancelledError:
+            raise RuntimeError("Loser blew up on cancel") from None
+        raise RuntimeError("Should not finish")
+
+    with (
+        patch(
+            "aiohttp_asyncmdnsresolver._impl.AsyncResolver.resolve",
+            _dns_swallows_cancel_and_raises,
+        ),
+        patch.object(IPv4HostResolver, "async_request", return_value=True),
+        patch.object(
+            IPv4HostResolver,
+            "ip_addresses_by_version",
+            return_value=[IPv4Address("127.0.0.1")],
+        ),
+    ):
+        results = await dual_resolver.resolve("localhost.local.")
+
+    assert results is not None
+    assert len(results) == 1
+    assert results[0]["host"] == "127.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_loser_wait_dual_mdns_resolver(
+    dual_resolver: AsyncDualMDNSResolver,
+) -> None:
+    """Test cancellation while waiting for the loser (after winner failed) propagates."""
+    dns_cancelled = False
+
+    async def _mdns_fast_failure(*args: Any, **kwargs: Any) -> NoReturn:
+        raise OSError(None, "MDNS lookup failed")
+
+    async def _dns_slow(*args: Any, **kwargs: Any) -> NoReturn:
+        nonlocal dns_cancelled
+        try:
+            await asyncio.sleep(1.0)
+        except asyncio.CancelledError:
+            dns_cancelled = True
+            raise
+        raise RuntimeError("Should not finish")
+
+    with (
+        patch("aiohttp_asyncmdnsresolver._impl.AsyncResolver.resolve", _dns_slow),
+        patch.object(IPv4HostResolver, "async_request", _mdns_fast_failure),
+    ):
+        resolve_task = asyncio.create_task(dual_resolver.resolve("localhost.local."))
+        await asyncio.sleep(0.05)
+        resolve_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await resolve_task
+
+    assert dns_cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_cancel_after_winner_completes_dual_mdns_resolver(
+    dual_resolver: AsyncDualMDNSResolver,
+) -> None:
+    """Test cancellation arriving while the loser is being drained propagates."""
+    dns_cancelled = False
+
+    async def _dns_slow(*args: Any, **kwargs: Any) -> NoReturn:
+        nonlocal dns_cancelled
+        try:
+            await asyncio.sleep(1.0)
+        except asyncio.CancelledError:
+            dns_cancelled = True
+            raise
+        raise RuntimeError("Should not finish")
+
+    with (
+        patch("aiohttp_asyncmdnsresolver._impl.AsyncResolver.resolve", _dns_slow),
+        patch.object(IPv4HostResolver, "async_request", return_value=True),
+        patch.object(
+            IPv4HostResolver,
+            "ip_addresses_by_version",
+            return_value=[IPv4Address("127.0.0.1")],
+        ),
+    ):
+        resolve_task = asyncio.create_task(dual_resolver.resolve("localhost.local."))
+        # Yield enough times for resolve() to advance past asyncio.wait, collect
+        # the mDNS result and enter the gather await inside the finally block.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        resolve_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await resolve_task
+
+    assert dns_cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_double_cancel_dual_mdns_resolver(
+    dual_resolver: AsyncDualMDNSResolver,
+) -> None:
+    """Test that double-cancelling resolve() still propagates CancelledError."""
+    cancelled = {"mdns": False, "dns": False}
+
+    async def _mdns_op(*args: Any, **kwargs: Any) -> NoReturn:
+        try:
+            await asyncio.sleep(1.0)
+        except asyncio.CancelledError:
+            cancelled["mdns"] = True
+            raise
+        raise RuntimeError("Should not finish")
+
+    async def _dns_op(*args: Any, **kwargs: Any) -> NoReturn:
+        try:
+            await asyncio.sleep(1.0)
+        except asyncio.CancelledError:
+            cancelled["dns"] = True
+            raise
+        raise RuntimeError("Should not finish")
+
+    with (
+        patch("aiohttp_asyncmdnsresolver._impl.AsyncResolver.resolve", _dns_op),
+        patch.object(IPv4HostResolver, "async_request", _mdns_op),
+    ):
+        resolve_task = asyncio.create_task(dual_resolver.resolve("localhost.local."))
+        await asyncio.sleep(0.05)
+        resolve_task.cancel()
+        resolve_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await resolve_task
+
+    assert cancelled["mdns"] is True
+    assert cancelled["dns"] is True


### PR DESCRIPTION
## Summary
- Wrap the wait and result collection in `AsyncDualMDNSResolver.resolve()` in try/finally so both child tasks get cancelled when the outer coroutine is cancelled; otherwise `asyncio.wait` leaves them running against the shared `zeroconf` instance.
- Lift and cleanup of #70, fixes #69.

## Test plan
- [x] New regression test asserts both child tasks observe `CancelledError`.
- [x] Existing `test_no_cancel_swallow_dual_mdns_resolver` still passes.
- [x] pytest, ruff, mypy clean locally.